### PR TITLE
Update build.zig for zig 0.11

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
     });
     const t = lib.target_info.target;
 
-    lib.addIncludePath("include");
+    lib.addIncludePath(std.Build.LazyPath{ .path = "include" });
     lib.addCSourceFiles(&generic_src_files, &.{});
     lib.defineCMacro("SDL_USE_BUILTIN_OPENGL_DEFINITIONS", "1");
     lib.linkLibC();


### PR DESCRIPTION
`std.Build.LibExeObjStep.addIncludePath` was updated to use `LazyPath` instead of `[]const u8`. By creating a `LazyPath` with `.path`, this can now be build with zig 0.11.